### PR TITLE
feat(jsx-plugin): allow noImports option for jsx plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,41 +11,50 @@
 #### The Fastest Framework Ever?
 The **UNBELIEVABLE** results of first implemented performance benchmark - `color-picker` from [Atom-iQ/isomorphic-ui-benchmarks](https://github.com/Atom-iQ/isomorphic-ui-benchmarks)
 (the fork of [marko-js/isomorphic-ui-benchmarks](https://github.com/marko-js/isomorphic-ui-benchmarks)) - are proving, that **Atom-iQ**, with **Reactive Virtual DOM** architecture,
-is **OUTPERFORMING** even the fastest **Virtual DOM** libraries/frameworks. Example results of the **benchmark**, with doubled **colors** array size (266 colors):
+is **OUTPERFORMING** even the fastest **Virtual DOM** libraries/frameworks.
+
+Average results of the **benchmark** (_Chrome_) - cases with different array sizes - **from 266 to 2128 colors** (original **benchmark** ran on **133 colors**):
+
+- Atom-iQ 14388 ops/sec
+- Inferno 3524 ops/sec (~4x slower)
+- React 1712 ops/sec (~8x slower)
+- Preact 1197 ops/sec (~12x slower)
+- Vue 929 ops/sec (~15x slower)
+
+###### *Average from 3 results for 266, 532, 1064 and 2128 colors
+
+Example result (266 colors):
 ```
 Warming up...
 Warmup complete.
 Running "color-picker"...
 Running benchmark "preact"...
-preact x 2,619 ops/sec ±0.57% (61 runs sampled)
+preact x 2,681 ops/sec ±0.44% (61 runs sampled)
 Running benchmark "react"...
-react x 3,471 ops/sec ±1.01% (56 runs sampled)
+react x 3,618 ops/sec ±0.81% (58 runs sampled)
 Running benchmark "vue"...
-vue x 2,019 ops/sec ±2.48% (59 runs sampled)
+vue x 2,039 ops/sec ±2.51% (56 runs sampled)
 Running benchmark "inferno"...
-inferno x 7,186 ops/sec ±0.57% (61 runs sampled)
+inferno x 7,411 ops/sec ±0.60% (58 runs sampled)
 Running benchmark "atom-iq"...
-atom-iq x 29,346 ops/sec ±1.78% (41 runs sampled)
+atom-iq x 27,995 ops/sec ±1.73% (41 runs sampled)
 Fastest is atom-iq
 ```
-While one of the fastest libraries on the market - **Inferno** is achieving over **7k ops/sec**, **Atom-iQ** has almost **30k** !!!
-**Atom-iQ** is also achieving better 1064 colors result (**~9k ops/sec**), than **Inferno** with 266 colors.
 
-> #### From benchmark repo
-> ###### Chrome 85
-> Worth notice is the fact, that for every array doubling, difference between the **Atom-iQ**, and the
-> rest is bigger. So, from all cases, from 266 to 2128 colors, **Atom-iQ** is `~3.6-4.9x` faster than **Inferno**,
-> `~7.4-10.8x` faster than **React**, `~10.1-15.6x` faster than **Preact**, `~13.2-23x` faster than **Vue**
->
-> ###### Firefox 81 (only 266 colors case)
-> Interesting is that all **Virtual DOM** frameworks are about **2x slower** on **Firefox**, than on **Chrome**, while **Atom-iQ** (**Reactive
-> Virtual DOM**) is even faster on **Firefox**. On **Firefox**, **Atom-iQ** is `~8x` faster than **Inferno**, `~17x` faster than **React**,
-> `~19x` faster than **Preact**, and `~25x` faster than **Vue**.
->
-> ###### Safari 13 (only 266 colors case)
-> Another interesting case - **Virtual DOM** libraries are `~20-30%` slower than on **Chrome**, **Atom-iQ** is even `~40%` faster on **Safari**
+While one of the fastest libraries on the market - **Inferno** is achieving over **7k ops/sec**, **Atom-iQ** has almost **28k** !!!
+**Atom-iQ** is also achieving better **1064 colors** result (**~9k ops/sec**), than **Inferno** with **266 colors**.
 
 [more details in benchmark repo](https://github.com/Atom-iQ/isomorphic-ui-benchmarks)
+
+Why is **Atom-iQ** that fast? The answer is **Reactive Virtual DOM**. In this benchmark one operation - set state - selected color index,
+leads finally to 2 small DOM changes - set `Element.className` in 2 **Elements** - in one to `"color selected"`, and in one selected before,
+back to `"color"`.
+- While in **Virtual DOM** libraries, that operation (set state) is causing reconciliation - diffing **Component's Virtual DOM** tree, and in
+  result, set `Element.className` in 2 **Elements**
+- In **Reactive Virtual DOM**, that operation is called _next state_, and is _streaming__ new `className` (string) to 2 _connected_ **Reactive
+  Virtual DOM Elements** (_Observers_). _Observers_ are just setting new `Element.className` for that 2 **Elements**. That change is not happening
+  in context of whole **Component**, but just those 2 single **RvdElement'**. So, in **Atom-iQ**, that update is a very small operation, in fact,
+  _it's almost only setting `Element.className` for 2 **Elements**_, **Atom-iQ** can make updates faster than browser can render it.
 
 > I'm excited to implement next performance benchmarks, it's clearly showing, that there is sense to develop **Atom-iQ**, as probably the fastest framework
 > ever.

--- a/dev-packages/babel-plugin-jsx/package.json
+++ b/dev-packages/babel-plugin-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-iq/babel-plugin-jsx",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Turn JSX into Atom-iQ Reactive Virtual DOM - fork of babel-plugin-inferno",
   "repository": "https://github.com/atom-iq/atom-iq/tree/master/dev-packages/babel-plugin-jsx",
   "license": "MIT",

--- a/dev-packages/babel-plugin-jsx/src/index.js
+++ b/dev-packages/babel-plugin-jsx/src/index.js
@@ -598,6 +598,9 @@ module.exports = function () {
         },
         exit: function (path, state) {
           const fileState = state.file
+          const opts = state.opts
+
+          const noImports = opts.noImports || false
 
           const needsAnyImports = Boolean(
             fileState.get(fnComponent) ||
@@ -606,16 +609,13 @@ module.exports = function () {
               fileState.get(fnNormalize)
           )
 
-          if (needsAnyImports) {
-            const opts = state.opts
+          if (needsAnyImports && !noImports) {
             const importIdentifier = '@atom-iq/core'
 
             const importArray = []
 
             if (fileState.get(fnElement) && !path.scope.hasBinding(fnElement)) {
-              importArray.push(
-                t.importSpecifier(t.identifier(opts.pragma || fnElement), t.identifier(fnElement))
-              )
+              importArray.push(t.importSpecifier(t.identifier(fnElement), t.identifier(fnElement)))
             }
             if (fileState.get(fnFragment) && !path.scope.hasBinding(fnFragment)) {
               importArray.push(

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-iq/cli",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "license": "MIT",
   "description": "(Atom-)iQ CLI - Build and development tool for Atom-iQ Framework",
   "main": "lib/main.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-iq/core",
-  "version": "0.1.0-alpha.5",
+  "version": "0.1.0-alpha.6",
   "description": "Atom-iQ Core Library - Reactive Virtual DOM Renderer",
   "author": "Adam Filipek <adamfilipek1@gmail.com> (https://github.com/adamf92)",
   "license": "MIT",


### PR DESCRIPTION
Allow noImports option for @atom-iq/babel-plugin-jsx - then it can be used with manual imports